### PR TITLE
Añadimos opción para ignorar duplicados de calendar_dates

### DIFF
--- a/lib/gtfs/config.js
+++ b/lib/gtfs/config.js
@@ -16,6 +16,7 @@ const config = {
     },
   ],
   staticUrl: 'http://212.170.201.204:50080/GTFSRTapi/api/GTFSFile',
+  ignoreDuplicates: true,
 };
 
 module.exports = config;


### PR DESCRIPTION
Parece que es habitual que calendar_dates.txt venga con datos duplicados, lo que hace que haya un error de SQLite y deje de funcionar la app.

Añadiendo ignorar duplicados hace que funcione.