### PR TITLE
Revertimos para mostrar horas 24, 25... y fix indendaciones

### DIFF
--- a/lib/gtfs/index.js
+++ b/lib/gtfs/index.js
@@ -58,7 +58,9 @@ const initializeGtfs = async () => {
           // Luego de ejecutar getGtfs.js, ejecutar gtfs.importGtfs
           try {
             await gtfs.importGtfs(gtfsConfig);
-            console.log('gtfs.importGtfs ejecutado correctamente después de getGtfs.js');
+            console.log(
+              'gtfs.importGtfs ejecutado correctamente después de getGtfs.js',
+            );
           } catch (error) {
             console.error('Error al ejecutar gtfs.importGtfs:', error);
           }
@@ -119,27 +121,30 @@ const updateGtfsCache = async () => {
 // Obtenemos la información de todas las paradas
 const gtfsGetStops = async () => {
   const gtfsStops = await gtfs.getStops();
-  
-  const paradas = await Promise.all(gtfsStops.map(async (stop) => {
-    const routes = await gtfs.getRoutes({ stop_id: stop.stop_id });
-    const routeNames = routes.map(route => route.route_short_name || route.route_long_name);
-    
-    return {
-      parada: {
-        nombre: stop.stop_name,
-        numero: stop.stop_code,
-      },
-      // TODO: Ver si gtfs tiene datos del tipo de parada
-      lineas: {
-        ordinarias: routeNames, // Aquí obtenemos las líneas para esta parada
-      },
-      ubicacion: {
-        x: stop.stop_lon,
-        y: stop.stop_lat,
-      },
-    };
-  }));
-  
+
+  const paradas = await Promise.all(
+    gtfsStops.map(async (stop) => {
+      const routes = await gtfs.getRoutes({ stop_id: stop.stop_id });
+      const routeNames = routes.map(
+        (route) => route.route_short_name || route.route_long_name,
+      );
+
+      return {
+        parada: {
+          nombre: stop.stop_name,
+          numero: stop.stop_code,
+        },
+        // TODO: Ver si gtfs tiene datos del tipo de parada
+        lineas: {
+          ordinarias: routeNames, // Aquí obtenemos las líneas para esta parada
+        },
+        ubicacion: {
+          x: stop.stop_lon,
+          y: stop.stop_lat,
+        },
+      };
+    }),
+  );
   return paradas;
 };
 
@@ -152,59 +157,59 @@ const gtfsGetStop = async (stopNumber, routeShortName, date) => {
     numeroParada: stop.stop_code,
     latitud: stop.stop_lat,
     longitud: stop.stop_lon,
-    url: `http://www.auvasa.es/parada.asp?codigo=${stop.stop_code}`,
+    url: `https://www.auvasa.es/mapa-de-servicios/?parada=${stop.stop_code}`,
     datosFecha: date,
   }));
-  
+
   const stopTimes = await gtfs.getStoptimes({ stop_id: gtfsStop[0].stop_id });
   // Utiliza Set para reducir a valores únicos y mejorar la búsqueda posterior
   const uniqueTripIds = new Set(stopTimes.map((stopTime) => stopTime.trip_id));
-  
+
   const trips = await gtfs.getTrips({
     trip_id: Array.from(uniqueTripIds),
   });
   // Utiliza Map para acceder a las rutas por id en O(1)
   const routeMap = new Map(trips.map((trip) => [trip.route_id, trip]));
-  
   const gtfsRoutes = await gtfs.getRoutes({
     route_id: Array.from(routeMap.keys()),
   });
 
   // Crear un mapa de trip_headsigns por route_id
-  const tripHeadsignMap = new Map(trips.map(trip => [trip.route_id, trip.trip_headsign]));
+  const tripHeadsignMap = new Map(
+    trips.map((trip) => [trip.route_id, trip.trip_headsign]),
+  );
 
   const routes = routeShortName
     ? gtfsRoutes.filter((route) => route.route_short_name === routeShortName)
     : gtfsRoutes;
 
-  const lineas = await Promise.all(routes.map(async route => {
-    const horarios = await getStopSchedule(
-      {
-        stop_id: gtfsStop[0].stop_id, 
-        route_id: route.route_id 
-      },
-      date
-    );
-    const realtime = await getRTStopTimes({ stopTimes, route });
-    
-    const destino = tripHeadsignMap.get(route.route_id) || "";
+  const lineas = await Promise.all(
+    routes.map(async (route) => {
+      const horarios = await getStopSchedule(
+        {
+          stop_id: gtfsStop[0].stop_id,
+          route_id: route.route_id,
+        },
+        date,
+      );
+      const realtime = await getRTStopTimes({ stopTimes, route });
+      const destino = tripHeadsignMap.get(route.route_id) || '';
 
-    return {
-      linea: route.route_short_name,
-      // FIXME: El destino ya no se mostrará global por línea, si no por cada trip individual. Pendiente de borrar del endpoint.
-      destino: destino,
-      
-      horarios,
-      realtime,
-    };
-  }));
+      return {
+        linea: route.route_short_name,
+        // FIXME: El destino ya no se mostrará global por línea, si no por cada trip individual. Pendiente de borrar del endpoint.
+        destino: destino,
+        horarios,
+        realtime,
+      };
+    }),
+  );
 
   return {
     parada,
     lineas,
   };
 };
-
 
 // Caché de los service_ids activos
 let activeServiceIdsCache = {};
@@ -213,10 +218,17 @@ let activeServiceIdsCache = {};
 const getActiveServiceIds = async (date) => {
   const now = date ? moment(date, 'YYYYMMDD').toDate() : new Date();
   const currentDate = parseInt(moment(now).format('YYYYMMDD'));
-  const lastMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const lastMidnight = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  );
 
   // Verificar si los service_id ya están actualizados para la fecha proporcionada o el día actual
-  if (!activeServiceIdsCache[currentDate] || activeServiceIdsCache[currentDate].lastUpdate < lastMidnight) {
+  if (
+    !activeServiceIdsCache[currentDate] ||
+    activeServiceIdsCache[currentDate].lastUpdate < lastMidnight
+  ) {
     const calendarDates = await gtfs.getCalendarDates();
 
     const activeServiceIds = calendarDates
@@ -234,6 +246,8 @@ const getActiveServiceIds = async (date) => {
 };
 
 // Calcula las horas ajustadas al rango 00-23
+// Esta función ya no tiene uso porque debemos observar las horas 24 25 26 27 para
+// saber que son servicios que operan al día siguiente, no en el actual, como marca la especificación GTFS
 const adjustTime = (time) => {
   // Separa las horas y los minutos de la cadena de tiempo
   const [hours, minutes] = time.split(':');
@@ -251,43 +265,51 @@ const adjustTime = (time) => {
 // Esta función filtra los horarios de llegada de los autobuses en una parada dada,
 // considerando solo los servicios activos para el día actual.
 const getStopSchedule = async ({ stop_id, route_id }, date) => {
- // Obtiene los service_id activos para el día actual
- const activeServiceIds = await getActiveServiceIds(date);
+  // Obtiene los service_id activos para el día actual
+  const activeServiceIds = await getActiveServiceIds(date);
 
- // Recupera todos los viajes para la ruta especificada
- const allTrips = await gtfs.getTrips({ route_id });
+  // Recupera todos los viajes para la ruta especificada
+  const allTrips = await gtfs.getTrips({ route_id });
 
- // Filtra los viajes para incluir solo aquellos con service_id activo
- const activeTrips = allTrips.filter(trip => activeServiceIds.has(trip.service_id));
+  // Filtra los viajes para incluir solo aquellos con service_id activo
+  const activeTrips = allTrips.filter((trip) =>
+    activeServiceIds.has(trip.service_id),
+  );
 
- // Obtiene los tiempos de parada para la parada especificada
- const stopTimes = await gtfs.getStoptimes({ stop_id });
+  // Obtiene los tiempos de parada para la parada especificada
+  const stopTimes = await gtfs.getStoptimes({ stop_id });
 
- // Crea un mapa de trip_headsigns por trip_id para buscar el destino más rápido
- const tripHeadsignMap = new Map(activeTrips.map(trip => [trip.trip_id, trip.trip_headsign]));
+  // Crea un mapa de trip_headsigns por trip_id para buscar el destino más rápido
+  const tripHeadsignMap = new Map(
+    activeTrips.map((trip) => [trip.trip_id, trip.trip_headsign]),
+  );
 
- // Filtra los tiempos de parada para incluir solo aquellos que corresponden a viajes activos
- // y mapea los tiempos de parada a un formato más legible, incluyendo el tiempo restante y el destino
- const filteredStopTimes = stopTimes.filter(stopTime =>
-    activeTrips.some(trip => trip.trip_id === stopTime.trip_id)
- ).map(stopTime => ({
-    trip_id: stopTime.trip_id,
-    llegada: adjustTime(stopTime.arrival_time), // Ajusta la hora de llegada al rango 00-23
-    tiempoRestante: getRemainingMinutes(stopTime.arrival_time), // Calcula los minutos restantes hasta la llegada
-    destino: tripHeadsignMap.get(stopTime.trip_id) || "", // Obtiene el destino del viaje
- })).sort((a, b) => a.tiempoRestante - b.tiempoRestante); // Ordena los tiempos de parada por tiempo restante
+  // Filtra los tiempos de parada para incluir solo aquellos que corresponden a viajes activos
+  // y mapea los tiempos de parada a un formato más legible, incluyendo el tiempo restante y el destino
+  const filteredStopTimes = stopTimes
+    .filter((stopTime) =>
+      activeTrips.some((trip) => trip.trip_id === stopTime.trip_id),
+    )
+    .map((stopTime) => ({
+      trip_id: stopTime.trip_id,
+      llegada: stopTime.arrival_time,
+      tiempoRestante: getRemainingMinutes(stopTime.arrival_time), // Calcula los minutos restantes hasta la llegada
+      destino: tripHeadsignMap.get(stopTime.trip_id) || '', // Obtiene el destino del viaje
+    }))
+    .sort((a, b) => a.tiempoRestante - b.tiempoRestante); // Ordena los tiempos de parada por tiempo restante
 
-
- // Devuelve los tiempos de parada filtrados y ordenados
- return filteredStopTimes;
+  // Devuelve los tiempos de parada filtrados y ordenados
+  return filteredStopTimes;
 };
 
 // Obtenemos las actualizaciones en tiempo real de una parada
 const getRTStopTimes = async ({ stopTimes, route }) => {
- // Crear un mapa para búsqueda rápida
- const stopTimesMap = new Map(stopTimes.map(sT => [`${sT.trip_id}-${sT.stop_sequence}`, sT]));
+  // Crear un mapa para búsqueda rápida
+  const stopTimesMap = new Map(
+    stopTimes.map((sT) => [`${sT.trip_id}-${sT.stop_sequence}`, sT]),
+  );
 
- const rtStopTimes = (await getCachedRtStopTimes())
+  const rtStopTimes = (await getCachedRtStopTimes())
     .filter(rtSt => {
       const key = `${rtSt.trip_id}-${rtSt.stop_sequence}`;
       return rtSt.route_id === route.route_id && stopTimesMap.has(key);
@@ -295,7 +317,10 @@ const getRTStopTimes = async ({ stopTimes, route }) => {
     .map(async rtSt => {
       const key = `${rtSt.trip_id}-${rtSt.stop_sequence}`;
       const scheduledStop = stopTimesMap.get(key);
-      const arrivalTime = moment.tz(rtSt.arrival_timestamp, 'UTC').tz('Europe/Madrid').format('HH:mm:ss');
+      const arrivalTime = moment
+        .tz(rtSt.arrival_timestamp, 'UTC')
+        .tz('Europe/Madrid')
+        .format('HH:mm:ss');
 
       // Obtener la posición del vehículo
       const vehiclePosition = await gtfsGetBusPosition(rtSt.trip_id);
@@ -305,7 +330,7 @@ const getRTStopTimes = async ({ stopTimes, route }) => {
 
       return {
         trip_id: rtSt.trip_id,
-        llegada: adjustTime(arrivalTime), // Se limpia la hora
+        llegada: arrivalTime,
         tiempoRestante: getRemainingMinutes(arrivalTime),
         desfase: calculateTimeShift({ scheduledStop, rtSt }),
         latitud: hasVehiclePosition ? vehiclePosition[0].latitud : null,
@@ -314,13 +339,13 @@ const getRTStopTimes = async ({ stopTimes, route }) => {
       };
     });
 
- // Esperar a que todas las promesas se resuelvan
- const resolvedStopTimes = await Promise.all(rtStopTimes);
+  // Esperar a que todas las promesas se resuelvan
+  const resolvedStopTimes = await Promise.all(rtStopTimes);
 
- // Ordenar si es necesario
- resolvedStopTimes.sort((a, b) => a.llegada.localeCompare(b.llegada));
+  // Ordenar si es necesario
+  resolvedStopTimes.sort((a, b) => a.llegada.localeCompare(b.llegada));
 
- return resolvedStopTimes;
+  return resolvedStopTimes;
 };
 
 const getCachedRtStopTimes = async () => {


### PR DESCRIPTION
Volvemos a mostrar las horas 24:00 25:00... desde el api y dejamos a los clientes que las procesen.

Esto es debido a que es la única forma de que los clientes sepan que los horarios corresponden al día siguiente y no al actual y al parecer es la recomendación del estandar GTFS,